### PR TITLE
Feature: localstore en carrito

### DIFF
--- a/client/src/components/Cart/OrderItem/index.jsx
+++ b/client/src/components/Cart/OrderItem/index.jsx
@@ -5,6 +5,7 @@ import {
   addOrder,
   removeCart,
   removeOrder,
+  setLocalStorage,
 } from "../../../redux/actions/cart";
 import { List, Img, Li , Text , Amount, Button , Div , CloseButton} from "./styles";
 
@@ -17,7 +18,7 @@ export default function OrderItem({ item }) {
     cantidad: item.cantidad,
     subtotal:(item.precio*item.cantidad)
   })
-  const [shoppingCart ] = useSelector(state=>[state.cart.shoppingCart])
+  const [shoppingCart , cart ] = useSelector(state=>[state.cart.shoppingCart , state.cart])
   const [stock,setStock] = useState(0)
 
   const getStock = async ()=>{
@@ -35,6 +36,7 @@ export default function OrderItem({ item }) {
   
   useEffect(()=>{
     dispatch(addOrder(productOrder))
+    dispatch(setLocalStorage(cart))
   },[productOrder,shoppingCart])
   useEffect(()=>{
     getStock()
@@ -86,8 +88,9 @@ export default function OrderItem({ item }) {
             <Button onClick={decAmount}>-</Button>
             <p>{productOrder.cantidad}</p>
             <Button onClick={incAmount}>+</Button>            
-            {            
-              stock <= productOrder.cantidad ? (<span>Stock maximo</span>) : null
+            {     
+              stock ? stock<=productOrder.cantidad ? (<span>Stock maximo</span>) : null : null
+              // stock <= productOrder.cantidad ? (<span>Stock maximo</span>) : null
             }
           </Amount>
         </Li>

--- a/client/src/components/Nav/index.jsx
+++ b/client/src/components/Nav/index.jsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { logout } from "../../redux/actions/autenticacion";
 import Loading from "../Loader";
+import { clearLocalStorage } from "../../redux/actions/cart";
 
 export default function NavBar({ products }) {
   const navigation = useNavigate();
@@ -37,6 +38,7 @@ export default function NavBar({ products }) {
 
   const logOut = () => {
     dispatch(logout());
+    dispatch(clearLocalStorage())
     navigation("/");
     document.cookie =
       "FOOD-API=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";

--- a/client/src/components/PopUp/index.jsx
+++ b/client/src/components/PopUp/index.jsx
@@ -1,6 +1,7 @@
+import { useEffect } from "react";
 import { useState } from "react";
-import { useDispatch } from "react-redux";
-import { modifyCart, removeCart } from "../../redux/actions/cart";
+import { useDispatch, useSelector } from "react-redux";
+import { modifyCart, removeCart, setLocalStorage } from "../../redux/actions/cart";
 
 import {
   MainDiv,
@@ -29,9 +30,14 @@ export default function AddPopUp({ id, nombre, img, precio, close , talle , chec
     cantidad: 1,
     precio: precio,
   })
-
+  const cart = useSelector(state=>state.cart)
   const dispatch = useDispatch();
 
+  useEffect(()=>{
+    return ()=>{
+      dispatch(setLocalStorage(cart))
+    }
+  },[])
   const incAmount = () => {
     setpedido({
       ...pedido,

--- a/client/src/containers/CartContainer/index.jsx
+++ b/client/src/containers/CartContainer/index.jsx
@@ -1,17 +1,23 @@
 import { useEffect, useState } from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { List, Li , Error , Div , Header , CatList , Main, PriceSection} from "./styles";
 import OrderItem from '../../components/Cart/OrderItem';
 import { Link } from "react-router-dom";
+import { setLocalStorage } from "../../redux/actions/cart";
 export default function ShoppingCart() {
-  const [shoppingCart,order] = useSelector((store) => [store.cart.shoppingCart,store.cart.order]);
+  const [cart , shoppingCart,order] = useSelector((store) => [store.cart , store.cart.shoppingCart,store.cart.order]);
   const [alert,setAlert] = useState(1)
   const [amount,setAmount] = useState(shoppingCart.length)
   // const [price , setPrice] = useState(0)
-  
+  const dispatch = useDispatch()
   useEffect(()=>{
     setAmount(shoppingCart.length)
   },[shoppingCart.length])
+  useEffect(()=>{
+    return () =>{
+      dispatch(setLocalStorage(cart))
+    }
+  },[])
 
   
   const price = order.reduce((prev,compra)=> prev+compra.subtotal,0)

--- a/client/src/pages/Detail/index.jsx
+++ b/client/src/pages/Detail/index.jsx
@@ -20,7 +20,7 @@ import {
   Review,
 } from "./styles";
 import { getProduct , deleteProduct } from "../../redux/actions/product";
-import {addToCart} from "../../redux/actions/cart"
+import {addToCart, setLocalStorage} from "../../redux/actions/cart"
 import Loading from "../../components/Loader";
 
 const colors = {
@@ -56,12 +56,13 @@ const ProductDetail = () => {
   };
 
   let dispatch = useDispatch();
-
-  let product = useSelector((state) => state.product.product);
-  let error = useSelector((state) => state.product.error);
+  let [cart , product , error] = useSelector ( state => [ state.cart , state.product.product , state.product.error])
+  // let product = useSelector((state) => state.product.product);
+  // let error = useSelector((state) => state.product.error);
   let { productId } = useParams();
 
   useEffect(()=>{
+    window.scrollTo(0,0); 
     if (!Object.keys(product).length){
       dispatch(getProduct(productId))
     }
@@ -73,10 +74,10 @@ const ProductDetail = () => {
   },[product])
   useEffect(()=>{
     return ()=>{
-
+      dispatch(setLocalStorage(cart))
       dispatch(deleteProduct())
     }
-  }, [productId]);
+  }, []);
 
   const checkStock = async (cantidad = 1) =>{
     let talle = size

--- a/client/src/redux/actions/cart.js
+++ b/client/src/redux/actions/cart.js
@@ -46,3 +46,23 @@ export const removeOrder = (id,talle) => {
   }
   };
 };
+export const setLocalStorage = (data)=>{
+  let item = JSON.parse(localStorage.getItem("cart"))
+  if (!item){
+    localStorage.setItem("cart",JSON.stringify(data))
+  }else{ 
+    item.shoppingCart = data.shoppingCart
+    item.order = data.order
+    localStorage.setItem("cart",JSON.stringify(item))
+  }
+
+  return {
+    type: 'SET_LOCAL_CART',    
+  }
+}
+export const clearLocalStorage = ()=>{
+  localStorage.removeItem("cart")
+  return{
+    type: "REMOVE_LOCAL_CART"
+  }
+}

--- a/client/src/redux/reducers/cart.js
+++ b/client/src/redux/reducers/cart.js
@@ -6,7 +6,14 @@ import {
   REMOVE_CART,
 } from "../actions/actionTypes";
 
-const initialState = {
+const cart = JSON.parse(localStorage.getItem("cart"))
+const initialState = cart ? {
+  shoppingCart: cart.shoppingCart,
+  order: cart.order,
+  loading:false,
+  error:null,
+} :
+{
   shoppingCart: [],
   order: [],
   loading: false,
@@ -71,6 +78,16 @@ export default function cartReducer(state = initialState, action) {
       return {
         ...state,        
       };
+    case "SET_LOCAL_CART":
+      return{
+        ...state
+      }
+    case "REMOVE_LOCAL_CART":
+      return{
+        ...state,
+        shoppingCart:[],
+        order:[]
+      }
     default:
       return state;
   }


### PR DESCRIPTION
Add localState para evitar perder el carrito al recargar la pagina. Se sale del mismo con el boton de desloguear. falta agregar la funcionalidad luego de finalizada la compra

Ideas para el tema de incorporar el carrito en la DB para el user:
Modelo de carrito ↓
![image](https://user-images.githubusercontent.com/92822629/179334447-6a33eb75-525b-4e1f-bbda-f03ac06a23ad.png)
con relaciones
 un usuario muchos cart (que cada item del carrito sea una linea en la tabla)

Ruta que busca el usuario y obtiene (entre otros datos) todos los objetos del carrito para filtrar en front (o al menos era la idea) ↓
![image](https://user-images.githubusercontent.com/92822629/179334450-d8a4afdf-ca50-469f-b96b-5d43b6ba7e4d.png)

Ruta para hacer el post del carrrito ↓
![image](https://user-images.githubusercontent.com/92822629/179334452-42d0d9f4-618d-4dac-949b-5bc1c60a8006.png)
