### PR TITLE
Fix: generar boton de pago ahora funciona como deber.

### DIFF
--- a/client/.env
+++ b/client/.env
@@ -1,0 +1,1 @@
+VITE_REACT_GOOGLE_ID=586049846286-8dm4fi9m9nddtv677qgll5tqbh1lvb4k.apps.googleusercontent.com

--- a/client/src/pages/Checkout/Checkout.jsx
+++ b/client/src/pages/Checkout/Checkout.jsx
@@ -25,8 +25,6 @@ const Checkout = () => {
 
     async function onClickHandler(e){
         e.preventDefault();
-        setBotonBloqueado("disabled");
-        setFormBloqueado("disabled");
         const pedido = {
             "productos": crearProductosPedido(carrito),
             "comprador": input,
@@ -67,7 +65,9 @@ const Checkout = () => {
                 b.parentNode.removeChild(b);
             }
         }
-        if(pago.id && MercadoPago){
+        if(pago.id && MercadoPago && botonBloqueado !== "disabled"){
+            setBotonBloqueado("disabled");
+            setFormBloqueado("disabled");
             const mp = new MercadoPago("APP_USR-06027043-b2a5-4576-ac25-217e1bbfc148", {
                 locale: "es-AR",
             })

--- a/client/src/pages/Checkout/Checkout.jsx
+++ b/client/src/pages/Checkout/Checkout.jsx
@@ -15,7 +15,7 @@ const Checkout = () => {
     const [errores, setErrores] = useState({nombre: "", apellido: "", documento: "", direccion: "", codigoPostal: "", provincia: ""});
     const [botonBloqueado, setBotonBloqueado] = useState("disabled");
     const [formBloqueado, setFormBloqueado] = useState("");
-    const carrito = useSelector(state => state.cart.order);
+    const carrito = useSelector(state => state.cart.shoppingCart);
     const { user: currentUser } = useSelector((state) => state.auth);
     //----------------------------MERCADOPAGO----------------------------------------
     const { MercadoPago } = useScript( "https://sdk.mercadopago.com/js/v2", "MercadoPago");
@@ -59,6 +59,14 @@ const Checkout = () => {
     },[])
 
     useEffect(() => {
+        console.log(pago);
+        const btn = document.getElementsByClassName("mercadopago-button");
+        console.log(btn);
+        if(btn[0]){
+            for(let b of btn){
+                b.parentNode.removeChild(b);
+            }
+        }
         if(pago.id && MercadoPago){
             const mp = new MercadoPago("APP_USR-06027043-b2a5-4576-ac25-217e1bbfc148", {
                 locale: "es-AR",
@@ -73,10 +81,10 @@ const Checkout = () => {
                 },
                 })
         }
-    },[pago, MercadoPago]);
+    },[pago]);
      //----------------------------FIN--MERCADOPAGO--------------------------------------
 
-    //  console.log(carrito);
+     console.log(carrito);
     //  console.log(currentUser);
 
      useEffect(

--- a/client/src/pages/Checkout/Checkout.jsx
+++ b/client/src/pages/Checkout/Checkout.jsx
@@ -9,6 +9,7 @@ import estilos from "./checkout.module.css";
 import useScript from "./useScript";
 import { useState } from "react";
 import {checkout, crearPedido, guardarDatosComprador} from "../../redux/actions/checkout"
+import { deleteCart } from "../../redux/actions/cart";
 
 const Checkout = () => {
     const [input, setInput] = useState({nombre: "", apellido: "", documento: "", direccion: "", codigoPostal: "", provincia: ""});
@@ -57,9 +58,9 @@ const Checkout = () => {
     },[])
 
     useEffect(() => {
-        console.log(pago);
+        // console.log(pago);
         const btn = document.getElementsByClassName("mercadopago-button");
-        console.log(btn);
+        // console.log(btn);
         if(btn[0]){
             for(let b of btn){
                 b.parentNode.removeChild(b);
@@ -80,11 +81,12 @@ const Checkout = () => {
                     label: "Pagar", // Cambia el texto del botón de pago (opcional)
                 },
                 })
+            dispatch(deleteCart());
         }
     },[pago]);
      //----------------------------FIN--MERCADOPAGO--------------------------------------
 
-     console.log(carrito);
+    //  console.log(carrito);
     //  console.log(currentUser);
 
      useEffect(

--- a/client/src/redux/actions/actionTypes.js
+++ b/client/src/redux/actions/actionTypes.js
@@ -47,3 +47,5 @@ export const PUT_USUARIOS = "PUT_USUARIOS";
 export const GET_FACTURA = "GET_FACTURA";
 export const APROBAR_PEDIDO = "APROBAR_PEDIDO";
 
+export const DELETE_CART = "DELETE_CART";
+

--- a/client/src/redux/actions/cart.js
+++ b/client/src/redux/actions/cart.js
@@ -1,5 +1,6 @@
 import {
   ADD_CART,
+  DELETE_CART,
   MODIFY_CART,
   PRICE_CART,
   PRICE_REMOVE_CART,
@@ -64,5 +65,12 @@ export const clearLocalStorage = ()=>{
   localStorage.removeItem("cart")
   return{
     type: "REMOVE_LOCAL_CART"
+  }
+}
+
+export const deleteCart = () => {
+  console.log("deleteeeeedddd");
+  return{
+    type: DELETE_CART
   }
 }

--- a/client/src/redux/actions/checkout.js
+++ b/client/src/redux/actions/checkout.js
@@ -25,7 +25,7 @@ export const guardarDatosComprador = (checkoutData) => async dispatch => {
 
 export const crearPedido = (pedido) => async dispatch => {
   const {data} = await axios.post(`${URL_SERVER}/pedido/crear`, pedido, { withCredentials: true });
-  console.log(data)
+  // console.log(data)
   return dispatch ({
     type: CREAR_PEDIDO,
     payload: data

--- a/client/src/redux/reducers/cart.js
+++ b/client/src/redux/reducers/cart.js
@@ -1,5 +1,6 @@
 import {
   ADD_CART,
+  DELETE_CART,
   MODIFY_CART,
   PRICE_CART,
   PRICE_REMOVE_CART,
@@ -86,6 +87,13 @@ export default function cartReducer(state = initialState, action) {
       return {
         ...state,        
       };
+    case DELETE_CART:
+      console.log("a");
+      return{
+        ...state,
+        shoppingCart:[],
+        order:[]
+      }
     case "SET_LOCAL_CART":
       return{
         ...state

--- a/server/src/routes/checkout.js
+++ b/server/src/routes/checkout.js
@@ -16,10 +16,12 @@ router.post("/", (req, res) => {
         const productos = [];
         carrito.map((p) => {
             let item = {
-                title: "ropita bonita",
-                unit_price: p.subtotal / p.cantidad,
+                title: p.nombre,
+                unit_price: p.precio,
                 quantity: p.cantidad,
-                description: "ROPA"
+                description: p.descripcion,
+                picture_url: p.imagen,
+                category_id: p.talle,
             }
             productos.push(item);
         })
@@ -60,9 +62,11 @@ router.post("/", (req, res) => {
                 res.json(response.body);
             }).catch(function (error){
                 console.log(error);
+                res.send("Se ha producido un error");
             })
     }catch(e){
-        console.log(e);
+        console.log(error);
+        res.send("Se ha producido un error");
     }
 })
 


### PR DESCRIPTION
El boton podía no generarse. Esto debido a que utilizaba la orden del carrito, la cual se perdía al refrescar la página o hacer determinada acción. Ahora se hace con el cart.shoppingCart. Esto además permite personalizar aún más las cosas dentro de la pasarela (que aparezca el nombre, imagen etc).
Podía pasar que también al volver para la página anterior y luego entrar denuevo al checkout, que aparezcan muchos botones. Ahora ya valida para que no ocurra eso.